### PR TITLE
Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.user
 
 # Roslyn IntelliSense Cache
-*.sln.ide/
+.vs/
 
 # Build output
 */bin/

--- a/Rackspace.Net.UriTemplate/InternalRegexOptions.cs
+++ b/Rackspace.Net.UriTemplate/InternalRegexOptions.cs
@@ -35,6 +35,9 @@
         /// include <see cref="RegexOptions.CultureInvariant"/> and, when supported,
         /// <see cref="F:System.Text.RegularExpressions.RegexOptions.Compiled"/>.</para>
         /// </remarks>
+        /// <value>
+        /// The default <see cref="RegexOptions"/> to use when creating new <see cref="Regex"/> instances.
+        /// </value>
         public static RegexOptions Default
         {
             get

--- a/Rackspace.Net.UriTemplate/UriTemplate.cs
+++ b/Rackspace.Net.UriTemplate/UriTemplate.cs
@@ -118,6 +118,9 @@ namespace Rackspace.Net
         /// <summary>
         /// Gets the original template text the <see cref="UriTemplate"/> was constructed from.
         /// </summary>
+        /// <value>
+        /// The original template text the <see cref="UriTemplate"/> was constructed from.
+        /// </value>
         public string Template
         {
             get

--- a/Rackspace.Net.UriTemplate/UriTemplate.cs
+++ b/Rackspace.Net.UriTemplate/UriTemplate.cs
@@ -68,7 +68,7 @@ namespace Rackspace.Net
         /// A regular expression which matches a single <c>expression</c> within a URI Template.
         /// </summary>
         /// <remarks>
-        /// This regular expression has the following named captures.
+        /// <para>This regular expression has the following named captures.</para>
         /// <list type="table">
         /// <listheader>
         /// <term>Name</term>
@@ -297,11 +297,11 @@ namespace Rackspace.Net
         /// <param name="parameters">The parameter values.</param>
         /// <returns>A <see cref="Uri"/> object representing the expanded template.</returns>
         /// <exception cref="ArgumentNullException">
-        /// If <paramref name="baseAddress"/> is <see langword="null"/>.
+        /// <para>If <paramref name="baseAddress"/> is <see langword="null"/>.</para>
         /// <para>-or-</para>
         /// <para>If <paramref name="parameters"/> is <see langword="null"/>.</para>
         /// </exception>
-        /// <exception cref="ArgumentException">If <paramref name="baseAddress"/> is not an absolute URI.</exception>
+        /// <exception cref="ArgumentException"><para>If <paramref name="baseAddress"/> is not an absolute URI.</para></exception>
         public Uri BindByName(Uri baseAddress, IDictionary<string, string> parameters)
         {
             return BindByName<string>(baseAddress, parameters);
@@ -316,12 +316,12 @@ namespace Rackspace.Net
         /// <param name="parameters">The parameter values.</param>
         /// <returns>A <see cref="Uri"/> object representing the expanded template.</returns>
         /// <exception cref="ArgumentNullException">
-        /// If <paramref name="baseAddress"/> is <see langword="null"/>.
+        /// <para>If <paramref name="baseAddress"/> is <see langword="null"/>.</para>
         /// <para>-or-</para>
         /// <para>If <paramref name="parameters"/> is <see langword="null"/>.</para>
         /// </exception>
-        /// <exception cref="ArgumentException">If <paramref name="baseAddress"/> is not an absolute URI.</exception>
-        /// <exception cref="InvalidOperationException">If a variable reference with a prefix modifier expands to a collection or dictionary.</exception>
+        /// <exception cref="ArgumentException"><para>If <paramref name="baseAddress"/> is not an absolute URI.</para></exception>
+        /// <exception cref="InvalidOperationException"><para>If a variable reference with a prefix modifier expands to a collection or dictionary.</para></exception>
         public Uri BindByName(Uri baseAddress, IDictionary<string, object> parameters)
         {
             return BindByName<object>(baseAddress, parameters);
@@ -337,12 +337,12 @@ namespace Rackspace.Net
         /// <param name="parameters">The parameter values.</param>
         /// <returns>A <see cref="Uri"/> object representing the expanded template.</returns>
         /// <exception cref="ArgumentNullException">
-        /// If <paramref name="baseAddress"/> is <see langword="null"/>.
+        /// <para>If <paramref name="baseAddress"/> is <see langword="null"/>.</para>
         /// <para>-or-</para>
         /// <para>If <paramref name="parameters"/> is <see langword="null"/>.</para>
         /// </exception>
-        /// <exception cref="ArgumentException">If <paramref name="baseAddress"/> is not an absolute URI.</exception>
-        /// <exception cref="InvalidOperationException">If a variable reference with a prefix modifier expands to a collection or dictionary.</exception>
+        /// <exception cref="ArgumentException"><para>If <paramref name="baseAddress"/> is not an absolute URI.</para></exception>
+        /// <exception cref="InvalidOperationException"><para>If a variable reference with a prefix modifier expands to a collection or dictionary.</para></exception>
         public Uri BindByName<T>(Uri baseAddress, IDictionary<string, T> parameters)
         {
             if (baseAddress == null)
@@ -359,8 +359,8 @@ namespace Rackspace.Net
         /// Attempts to match a <see cref="Uri"/> to a <see cref="UriTemplate"/>.
         /// </summary>
         /// <remarks>
-        /// For detailed information about the behavior of this method, see the remarks in the
-        /// documentation for the <see cref="O:Rackspace.Net.UriTemplate.Match"/> methods.
+        /// <para>For detailed information about the behavior of this method, see the remarks in the
+        /// documentation for the <see cref="O:Rackspace.Net.UriTemplate.Match"/> methods.</para>
         /// </remarks>
         /// <param name="candidate">The <see cref="Uri"/> to match against the template.</param>
         /// <returns>A <see cref="UriTemplateMatch"/> object containing the results of the match operation, or <see langword="null"/> if the match failed.</returns>
@@ -377,19 +377,19 @@ namespace Rackspace.Net
         /// Attempts to match a <see cref="Uri"/> to a <see cref="UriTemplate"/>.
         /// </summary>
         /// <remarks>
-        /// For detailed information about the behavior of this method, see the remarks in the
-        /// documentation for the <see cref="O:Rackspace.Net.UriTemplate.Match"/> methods.
+        /// <para>For detailed information about the behavior of this method, see the remarks in the
+        /// documentation for the <see cref="O:Rackspace.Net.UriTemplate.Match"/> methods.</para>
         /// </remarks>
         /// <param name="candidate">The <see cref="Uri"/> to match against the template.</param>
         /// <param name="requiredVariables">A collection of variables which must be provided during the expansion process for the resulting URI to be valid.</param>
         /// <returns>A <see cref="UriTemplateMatch"/> object containing the results of the match operation, or <see langword="null"/> if the match failed. The default value is an empty collection.</returns>
         /// <exception cref="ArgumentNullException">
-        /// If <paramref name="candidate"/> is <see langword="null"/>.
+        /// <para>If <paramref name="candidate"/> is <see langword="null"/>.</para>
         /// <para>-or-</para>
         /// <para>If <paramref name="requiredVariables"/> is <see langword="null"/>.</para>
         /// </exception>
         /// <exception cref="ArgumentException">
-        /// If <paramref name="requiredVariables"/> contains a <see langword="null"/> or empty value.
+        /// <para>If <paramref name="requiredVariables"/> contains a <see langword="null"/> or empty value.</para>
         /// </exception>
         /// <conceptualLink target="7e56a038-ad98-4922-9342-7f68a5b89283"/>
         public UriTemplateMatch Match(Uri candidate, ICollection<string> requiredVariables)
@@ -401,22 +401,22 @@ namespace Rackspace.Net
         /// Attempts to match a <see cref="Uri"/> to a <see cref="UriTemplate"/>.
         /// </summary>
         /// <remarks>
-        /// For detailed information about the behavior of this method, see the remarks in the
-        /// documentation for the <see cref="O:Rackspace.Net.UriTemplate.Match"/> methods.
+        /// <para>For detailed information about the behavior of this method, see the remarks in the
+        /// documentation for the <see cref="O:Rackspace.Net.UriTemplate.Match"/> methods.</para>
         /// </remarks>
         /// <param name="candidate">The <see cref="Uri"/> to match against the template.</param>
         /// <param name="arrayVariables">A collection of variables to treat as associative arrays when matching a candidate URI to the template. Associative arrays are returned as instances of <see cref="IList{T}"/> whose values are of type <see cref="String"/>. The default value is an empty collection.</param>
         /// <param name="mapVariables">A collection of variables to treat as associative maps when matching a candidate URI to the template. Associative maps are returned as instances of <see cref="IDictionary{TKey, TValue}"/> whose keys and values are of type <see cref="String"/>. The default value is an empty collection.</param>
         /// <returns>A <see cref="UriTemplateMatch"/> object containing the results of the match operation, or <see langword="null"/> if the match failed.</returns>
         /// <exception cref="ArgumentNullException">
-        /// If <paramref name="candidate"/> is <see langword="null"/>.
+        /// <para>If <paramref name="candidate"/> is <see langword="null"/>.</para>
         /// <para>-or-</para>
         /// <para>If <paramref name="arrayVariables"/> is <see langword="null"/>.</para>
         /// <para>-or-</para>
         /// <para>If <paramref name="mapVariables"/> is <see langword="null"/>.</para>
         /// </exception>
         /// <exception cref="ArgumentException">
-        /// If <paramref name="arrayVariables"/> contains a <see langword="null"/> or empty value.
+        /// <para>If <paramref name="arrayVariables"/> contains a <see langword="null"/> or empty value.</para>
         /// <para>-or-</para>
         /// <para>If <paramref name="mapVariables"/> contains a <see langword="null"/> or empty value.</para>
         /// </exception>
@@ -434,7 +434,7 @@ namespace Rackspace.Net
         /// <see cref="O:Rackspace.Net.UriTemplate.BindByName"/> operation.
         /// </summary>
         /// <remarks>
-        /// There are several limitations in the current implementation of this operation.
+        /// <para>There are several limitations in the current implementation of this operation.</para>
         ///
         /// <list type="bullet">
         ///   <item>
@@ -472,8 +472,8 @@ namespace Rackspace.Net
         /// Attempts to match a <see cref="Uri"/> to a <see cref="UriTemplate"/>.
         /// </summary>
         /// <remarks>
-        /// For detailed information about the behavior of this method, see the remarks in the
-        /// documentation for the <see cref="O:Rackspace.Net.UriTemplate.Match"/> methods.
+        /// <para>For detailed information about the behavior of this method, see the remarks in the
+        /// documentation for the <see cref="O:Rackspace.Net.UriTemplate.Match"/> methods.</para>
         /// </remarks>
         /// <param name="candidate">The <see cref="Uri"/> to match against the template.</param>
         /// <param name="requiredVariables">A collection of variables which must be provided during the expansion process for the resulting URI to be valid. The default value is an empty collection.</param>
@@ -481,7 +481,7 @@ namespace Rackspace.Net
         /// <param name="mapVariables">A collection of variables to treat as associative maps when matching a candidate URI to the template. Associative maps are returned as instances of <see cref="IDictionary{TKey, TValue}"/> whose keys and values are of type <see cref="String"/>. The default value is an empty collection.</param>
         /// <returns>A <see cref="UriTemplateMatch"/> object containing the results of the match operation, or <see langword="null"/> if the match failed.</returns>
         /// <exception cref="ArgumentNullException">
-        /// If <paramref name="candidate"/> is <see langword="null"/>.
+        /// <para>If <paramref name="candidate"/> is <see langword="null"/>.</para>
         /// <para>-or-</para>
         /// <para>If <paramref name="requiredVariables"/> is <see langword="null"/>.</para>
         /// <para>-or-</para>
@@ -490,7 +490,7 @@ namespace Rackspace.Net
         /// <para>If <paramref name="mapVariables"/> is <see langword="null"/>.</para>
         /// </exception>
         /// <exception cref="ArgumentException">
-        /// If <paramref name="requiredVariables"/> contains a <see langword="null"/> or empty value.
+        /// <para>If <paramref name="requiredVariables"/> contains a <see langword="null"/> or empty value.</para>
         /// <para>-or-</para>
         /// <para>If <paramref name="arrayVariables"/> contains a <see langword="null"/> or empty value.</para>
         /// <para>-or-</para>
@@ -546,12 +546,12 @@ namespace Rackspace.Net
         /// <param name="candidate">The <see cref="Uri"/> to match against the template.</param>
         /// <returns>A <see cref="UriTemplateMatch"/> object containing the results of the match operation, or <see langword="null"/> if the match failed.</returns>
         /// <exception cref="ArgumentNullException">
-        /// If <paramref name="baseAddress"/> is <see langword="null"/>.
+        /// <para>If <paramref name="baseAddress"/> is <see langword="null"/>.</para>
         /// <para>-or-</para>
         /// <para>If <paramref name="candidate"/> is <see langword="null"/>.</para>
         /// </exception>
         /// <exception cref="InvalidOperationException">
-        /// If <paramref name="baseAddress"/> is a relative URI.
+        /// <para>If <paramref name="baseAddress"/> is a relative URI.</para>
         /// <para>-or-</para>
         /// <para>If <paramref name="candidate"/> is a relative URI.</para>
         /// </exception>

--- a/Rackspace.Net.UriTemplate/UriTemplate.cs
+++ b/Rackspace.Net.UriTemplate/UriTemplate.cs
@@ -408,8 +408,8 @@ namespace Rackspace.Net
         /// documentation for the <see cref="O:Rackspace.Net.UriTemplate.Match"/> methods.</para>
         /// </remarks>
         /// <param name="candidate">The <see cref="Uri"/> to match against the template.</param>
-        /// <param name="arrayVariables">A collection of variables to treat as associative arrays when matching a candidate URI to the template. Associative arrays are returned as instances of <see cref="IList{T}"/> whose values are of type <see cref="String"/>. The default value is an empty collection.</param>
-        /// <param name="mapVariables">A collection of variables to treat as associative maps when matching a candidate URI to the template. Associative maps are returned as instances of <see cref="IDictionary{TKey, TValue}"/> whose keys and values are of type <see cref="String"/>. The default value is an empty collection.</param>
+        /// <param name="arrayVariables">A collection of variables to treat as associative arrays when matching a candidate URI to the template. Associative arrays are returned as instances of <see cref="IList{T}"/> whose values are of type <see cref="string"/>. The default value is an empty collection.</param>
+        /// <param name="mapVariables">A collection of variables to treat as associative maps when matching a candidate URI to the template. Associative maps are returned as instances of <see cref="IDictionary{TKey, TValue}"/> whose keys and values are of type <see cref="string"/>. The default value is an empty collection.</param>
         /// <returns>A <see cref="UriTemplateMatch"/> object containing the results of the match operation, or <see langword="null"/> if the match failed.</returns>
         /// <exception cref="ArgumentNullException">
         /// <para>If <paramref name="candidate"/> is <see langword="null"/>.</para>
@@ -446,11 +446,11 @@ namespace Rackspace.Net
         ///     operation, it is unspecified which assignment of values is chosen.
         ///   </item>
         ///   <item>
-        ///     Simple string values will always be returned as a <see cref="String"/>.
+        ///     Simple string values will always be returned as a <see cref="string"/>.
         ///     Associative array values will always be returned as an <see cref="IList{T}"/> whose
-        ///     values are of type <see cref="String"/>. Associative map values will always be
+        ///     values are of type <see cref="string"/>. Associative map values will always be
         ///     returned as an <see cref="IDictionary{TKey, TValue}"/> whose keys and values are
-        ///     of type <see cref="String"/>. No other deserialization or coercion of values is
+        ///     of type <see cref="string"/>. No other deserialization or coercion of values is
         ///     performed by this library.
         ///   </item>
         /// </list>
@@ -480,8 +480,8 @@ namespace Rackspace.Net
         /// </remarks>
         /// <param name="candidate">The <see cref="Uri"/> to match against the template.</param>
         /// <param name="requiredVariables">A collection of variables which must be provided during the expansion process for the resulting URI to be valid. The default value is an empty collection.</param>
-        /// <param name="arrayVariables">A collection of variables to treat as associative arrays when matching a candidate URI to the template. Associative arrays are returned as instances of <see cref="IList{T}"/> whose values are of type <see cref="String"/>. The default value is an empty collection.</param>
-        /// <param name="mapVariables">A collection of variables to treat as associative maps when matching a candidate URI to the template. Associative maps are returned as instances of <see cref="IDictionary{TKey, TValue}"/> whose keys and values are of type <see cref="String"/>. The default value is an empty collection.</param>
+        /// <param name="arrayVariables">A collection of variables to treat as associative arrays when matching a candidate URI to the template. Associative arrays are returned as instances of <see cref="IList{T}"/> whose values are of type <see cref="string"/>. The default value is an empty collection.</param>
+        /// <param name="mapVariables">A collection of variables to treat as associative maps when matching a candidate URI to the template. Associative maps are returned as instances of <see cref="IDictionary{TKey, TValue}"/> whose keys and values are of type <see cref="string"/>. The default value is an empty collection.</param>
         /// <returns>A <see cref="UriTemplateMatch"/> object containing the results of the match operation, or <see langword="null"/> if the match failed.</returns>
         /// <exception cref="ArgumentNullException">
         /// <para>If <paramref name="candidate"/> is <see langword="null"/>.</para>

--- a/Rackspace.Net.UriTemplate/UriTemplateMatch.cs
+++ b/Rackspace.Net.UriTemplate/UriTemplateMatch.cs
@@ -41,7 +41,7 @@ namespace Rackspace.Net
         /// <para>If <paramref name="bindings"/> is <see langword="null"/>.</para>
         /// </exception>
         /// <exception cref="FormatException">
-        /// If <paramref name="bindings"/> contains two variable bindings for the same variable which do not have the same value, after considering the prefix modifier(s).
+        /// <para>If <paramref name="bindings"/> contains two variable bindings for the same variable which do not have the same value, after considering the prefix modifier(s).</para>
         /// </exception>
         internal UriTemplateMatch(UriTemplate template, IEnumerable<KeyValuePair<VariableReference, object>> bindings)
         {

--- a/Rackspace.Net.UriTemplate/UriTemplateMatch.cs
+++ b/Rackspace.Net.UriTemplate/UriTemplateMatch.cs
@@ -91,6 +91,9 @@ namespace Rackspace.Net
         /// <summary>
         /// Gets the <see cref="UriTemplate"/> associated with this <see cref="UriTemplateMatch"/> instance.
         /// </summary>
+        /// <value>
+        /// The <see cref="UriTemplate"/> associated with this <see cref="UriTemplateMatch"/> instance.
+        /// </value>
         public UriTemplate Template
         {
             get
@@ -102,6 +105,9 @@ namespace Rackspace.Net
         /// <summary>
         /// Gets a collection of bindings from variable name to the actual URI Template variable reference and bound value.
         /// </summary>
+        /// <value>
+        /// A collection of bindings from variable name to the actual URI Template variable reference and bound value.
+        /// </value>
         public IDictionary<string, KeyValuePair<VariableReference, object>> Bindings
         {
             get

--- a/Rackspace.Net.UriTemplate/UriTemplatePart.cs
+++ b/Rackspace.Net.UriTemplate/UriTemplatePart.cs
@@ -57,7 +57,7 @@ namespace Rackspace.Net
         /// <para>If <paramref name="mapVariables"/> is <see langword="null"/>.</para>
         /// </exception>
         /// <exception cref="ArgumentException">
-        /// If <paramref name="groupName"/> is empty.
+        /// <para>If <paramref name="groupName"/> is empty.</para>
         /// </exception>
         public void BuildPattern(StringBuilder pattern, string groupName, ICollection<string> requiredVariables, ICollection<string> arrayVariables, ICollection<string> mapVariables)
         {

--- a/Rackspace.Net.UriTemplate/UriTemplatePart.cs
+++ b/Rackspace.Net.UriTemplate/UriTemplatePart.cs
@@ -17,6 +17,9 @@ namespace Rackspace.Net
         /// <summary>
         /// Gets the type of this part.
         /// </summary>
+        /// <value>
+        /// A <see cref="UriTemplatePartType"/> indicating the type of this part.
+        /// </value>
         public abstract UriTemplatePartType Type
         {
             get;

--- a/Rackspace.Net.UriTemplate/UriTemplatePartExpansion.cs
+++ b/Rackspace.Net.UriTemplate/UriTemplatePartExpansion.cs
@@ -82,11 +82,11 @@ namespace Rackspace.Net
         /// <description>The variable is rendered by calling <see cref="RenderDictionary"/>.</description>
         /// </item>
         /// <item>
-        /// <description><see cref="IEnumerable"/> (except <see cref="String"/>)</description>
+        /// <description><see cref="IEnumerable"/> (except <see cref="string"/>)</description>
         /// <description>The variable is rendered by calling <see cref="RenderEnumerable"/>.</description>
         /// </item>
         /// <item>
-        /// <description><see cref="String"/>, or any other <see cref="Object"/></description>
+        /// <description><see cref="string"/>, or any other <see cref="object"/></description>
         /// <description>The variable is rendered by calling <see cref="RenderElement"/>.</description>
         /// </item>
         /// <item>
@@ -328,7 +328,7 @@ namespace Rackspace.Net
         protected abstract void RenderEnumerable(StringBuilder builder, VariableReference variable, IEnumerable variableValue, bool first);
 
         /// <summary>
-        /// Render a single variable, where the variable value is a <see cref="String"/> or other single-valued
+        /// Render a single variable, where the variable value is a <see cref="string"/> or other single-valued
         /// element.
         /// </summary>
         /// <param name="builder">The <see cref="StringBuilder"/> to render to.</param>

--- a/Rackspace.Net.UriTemplate/UriTemplatePartSimpleExpansion.cs
+++ b/Rackspace.Net.UriTemplate/UriTemplatePartSimpleExpansion.cs
@@ -27,7 +27,7 @@ namespace Rackspace.Net
         /// </summary>
         /// <param name="variables">A collection of variables to expand for this expression.</param>
         /// <param name="escapeReserved"><see langword="true"/> to escape reserved characters during rendering; otherwise, <see langword="false"/>.</param>
-        /// <exception cref="ArgumentNullException">If <paramref name="variables"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><para>If <paramref name="variables"/> is <see langword="null"/>.</para></exception>
         /// <exception cref="ArgumentException">
         /// <para>If <paramref name="variables"/> is empty.</para>
         /// <para>-or-</para>

--- a/Testing.Rfc6570/ExtendedTests.cs
+++ b/Testing.Rfc6570/ExtendedTests.cs
@@ -19,9 +19,9 @@
                 { "q"            , "URI Templates" },
                 { "page"         , "5" },
                 { "lang"         , "en" },
-                { "geocode"      , new[] { "37.76","-122.427" } },
+                { "geocode"      , new[] { "37.76", "-122.427" } },
                 { "first_name"   , "John" },
-                { "last.name"    , "Doe" }, 
+                { "last.name"    , "Doe" },
                 { "Some%20Thing" , "foo" },
                 { "number"       , 6 },
                 { "long"         , 37.76 },
@@ -34,6 +34,7 @@
                 { "random"       , "šöäŸœñê€£¥‡ÑÒÓÔÕÖ×ØÙÚàáâãäåæçÿ" },
                 { "assoc_special_chars", new Dictionary<string, string> { { "šöäŸœñê€£¥‡ÑÒÓÔÕ", "Ö×ØÙÚàáâãäåæçÿ" } } }
             };
+
         public static readonly HashSet<string> requiredVariables1 =
             new HashSet<string>
             {
@@ -63,16 +64,17 @@
         public static readonly Dictionary<string, object> variables2 =
             new Dictionary<string, object>
             {
-                { "id" , new[] { "person","albums" } },
+                { "id" , new[] { "person", "albums" } },
                 { "token" , "12345" },
-                { "fields" , new[] { "id", "name", "picture"} },
+                { "fields" , new[] { "id", "name", "picture" } },
                 { "format" , "atom" },
                 { "q" , "URI Templates" },
                 { "page" , "10" },
                 { "start" , "5" },
                 { "lang" , "en" },
-                { "geocode" , new[] { "37.76","-122.427" } }
+                { "geocode" , new[] { "37.76", "-122.427" } }
             };
+
         public static readonly HashSet<string> requiredVariables2 =
             new HashSet<string>
             {
@@ -93,18 +95,20 @@
                 { "empty_list", new string[0] },
                 { "empty_assoc", new Dictionary<string, string>() }
             };
+
         public static readonly ICollection<string> requiredVariables3 = new string[0];
 
         public static readonly Dictionary<string, object> variables4 =
             new Dictionary<string, object>
             {
                 { "42", "The Answer to the Ultimate Question of Life, the Universe, and Everything" },
-                { "1337", new[] { "leet", "as","it", "can","be" } },
+                { "1337", new[] { "leet", "as", "it", "can", "be" } },
                 { "german", new Dictionary<string, string> {
                     { "11", "elf" },
                     { "12", "zwölf" } }
                 }
             };
+
         public static readonly HashSet<string> requiredVariables4 =
             new HashSet<string>
             {

--- a/Testing.Rfc6570/Level1Tests.cs
+++ b/Testing.Rfc6570/Level1Tests.cs
@@ -14,6 +14,7 @@
                 { "var", "value" },
                 { "hello", "Hello World!" },
             };
+
         private static readonly HashSet<string> requiredVariables =
             new HashSet<string>
             {

--- a/Testing.Rfc6570/Level2Tests.cs
+++ b/Testing.Rfc6570/Level2Tests.cs
@@ -15,6 +15,7 @@
                 { "hello", "Hello World!" },
                 { "path", "/foo/bar" },
             };
+
         private static readonly HashSet<string> requiredVariables =
             new HashSet<string>
             {

--- a/Testing.Rfc6570/Level3Tests.cs
+++ b/Testing.Rfc6570/Level3Tests.cs
@@ -15,7 +15,7 @@
             {
                 { "var", "value" },
                 { "hello", "Hello World!" },
-                { "empty", "" },
+                { "empty", string.Empty },
                 { "path", "/foo/bar" },
                 { "x", "1024" },
                 { "y", "768" },

--- a/Testing.Rfc6570/Level3Tests.cs
+++ b/Testing.Rfc6570/Level3Tests.cs
@@ -20,6 +20,7 @@
                 { "x", "1024" },
                 { "y", "768" },
             };
+
         private static readonly HashSet<string> requiredVariables =
             new HashSet<string>
             {

--- a/Testing.Rfc6570/Level4Tests.cs
+++ b/Testing.Rfc6570/Level4Tests.cs
@@ -16,8 +16,9 @@
                 { "hello", "Hello World!" },
                 { "path", "/foo/bar" },
                 { "list", new[] { "red", "green", "blue" } },
-                { "keys", new Dictionary<string, string> { { "semi", ";" }, { "dot", "." }, { "comma", ","} } }
+                { "keys", new Dictionary<string, string> { { "semi", ";" }, { "dot", "." }, { "comma", "," } } }
             };
+
         private static readonly HashSet<string> requiredVariables =
             new HashSet<string>
             {

--- a/Testing.Rfc6570/NegativeTests.cs
+++ b/Testing.Rfc6570/NegativeTests.cs
@@ -19,7 +19,7 @@
                 { "with space"        , "fail" },
                 { " leading_space"    , "Hi!" },
                 { "trailing_space "   , "Bye!" },
-                { "empty"             , "" },
+                { "empty"             , string.Empty },
                 { "path"              , "/foo/bar" },
                 { "x"                 , "1024" },
                 { "y"                 , "768" },


### PR DESCRIPTION
* Update **.gitignore** for the latest releases of Visual Studio 2015
* Use `string.Empty` instead of `""`
* Fix whitespace inconsistencies
* Use `<para>` elements consistently in documentation
* Document property values
* Use built-in types where possible (e.g. use `string` instead of `String`)