### PR TITLE
fix legitimate Assert.AreEqual failed. Expected:</loc?long=37.76&lat=-122.427>. Actual:</loc?long=37%2C76&lat=-122%2C427> with CultureInfo("fr-BE")

### DIFF
--- a/Testing.Rfc6570/AssemblyInitialize.cs
+++ b/Testing.Rfc6570/AssemblyInitialize.cs
@@ -1,0 +1,16 @@
+﻿using System.Globalization;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Testing.Rfc6570
+{
+  [TestClass]
+  public class AssemblyInitialize
+  {
+    [AssemblyInitialize]
+    public static void AssemblyInitializer(TestContext testContext)
+    {
+      Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+    }
+  }
+}

--- a/Testing.Rfc6570/Testing.Rfc6570.portable-net40.csproj
+++ b/Testing.Rfc6570/Testing.Rfc6570.portable-net40.csproj
@@ -61,7 +61,9 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
+          <Private>False</Private>
+        </Reference>
       </ItemGroup>
     </Otherwise>
   </Choose>
@@ -74,6 +76,7 @@
     <Compile Include="NegativeTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestCategories.cs" />
+    <Compile Include="AssemblyInitialize.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TunnelVisionLabs.Net.UriTemplate\TunnelVisionLabs.Net.UriTemplate.portable-net40.csproj">


### PR DESCRIPTION
Testing.Rfc6570.ExtendedTests.TestQueryExpansionWithMultipleDoubleVariable()
dotnet-uritemplate\Testing.Rfc6570\ExtendedTests.cs:ligne 266
Result Message: Assert.AreEqual failed. Expected:&lt;/loc?long=37.76&lat=-122.427&gt;. Actual:&lt;/loc?long=37%2C76&lat=-122%2C427&gt;.
